### PR TITLE
Add deprecation notice to localgov_theme pages

### DIFF
--- a/docs/src/theme/README.md
+++ b/docs/src/theme/README.md
@@ -7,6 +7,12 @@ tags:
 
 # Frontend theme
 
+## Deprecated
+
+<span style="color:#B30000;">**This documentation is for the original localgov_theme and the associated localgov_skeleton theme, which have been superceded by the [localgov_base theme](https://github.com/localgovdrupal/localgov_base) documentation for which is in production.**</span>
+
+***
+
 [GitHub Repository](https://github.com/localgovdrupal/localgov_theme)
 
 The theme uses Bootstrap 4 and uses Gulp for compiling SASS to CSS. We aim for each library to be included and compiled separately so that child themes can selectively override each library they don't wish to inherit.

--- a/docs/src/theme/admin-theme.md
+++ b/docs/src/theme/admin-theme.md
@@ -1,5 +1,11 @@
 # Admin theme
 
+## Deprecated
+
+<span style="color:#B30000;">**This documentation is for the original localgov_theme and the associated localgov_skeleton theme, which have been superceded by the [localgov_base theme](https://github.com/localgovdrupal/localgov_base) documentation for which is in production.**</span>
+
+***
+
 [GitHub Repository](https://github.com/localgovdrupal/localgov_claro)
 
 The admin theme is a subtheme based on Claro, it will come with admin improvements and default config.

--- a/docs/src/theme/automated-tests.md
+++ b/docs/src/theme/automated-tests.md
@@ -1,5 +1,11 @@
 # Automated tests
 
+## Deprecated
+
+<span style="color:#B30000;">**This documentation is for the original localgov_theme and the associated localgov_skeleton theme, which have been superceded by the [localgov_base theme](https://github.com/localgovdrupal/localgov_base) documentation for which is in production.**</span>
+
+***
+
 The theme features some automated tests written with [Mocha.js](https://mochajs.org/) localed in `tests/`. The purpose of these tests is to ensure consistency between versions and deployments and to highlight any regression issues, particularly regarding Gulp.
 
 Mocha.js doesn't make assumptions about your assertion library of choice, in this project we opted for [Chai](https://www.chaijs.com/).

--- a/docs/src/theme/javascript.md
+++ b/docs/src/theme/javascript.md
@@ -1,3 +1,9 @@
 # Javascript
 
+## Deprecated
+
+<span style="color:#B30000;">**This documentation is for the original localgov_theme and the associated localgov_skeleton theme, which have been superceded by the [localgov_base theme](https://github.com/localgovdrupal/localgov_base) documentation for which is in production.**</span>
+
+***
+
 Currently Javascript is not being compiled or handled in anyway by Gulp so it's up to you how you structure your code. Code can be found in `/assets/js` and there is a mix of examples including jQuery and using Drupal behaviors.

--- a/docs/src/theme/regions.md
+++ b/docs/src/theme/regions.md
@@ -1,5 +1,11 @@
 # Regions
 
+## Deprecated
+
+<span style="color:#B30000;">**This documentation is for the original localgov_theme and the associated localgov_skeleton theme, which have been superceded by the [localgov_base theme](https://github.com/localgovdrupal/localgov_base) documentation for which is in production.**</span>
+
+***
+
 Styling documentation
 
 ## Sub heading for navigation

--- a/docs/src/theme/skeleton-theme.md
+++ b/docs/src/theme/skeleton-theme.md
@@ -1,10 +1,16 @@
 # Skeleton theme
 
+## Deprecated
+
+<span style="color:#B30000;">**This documentation is for the original localgov_theme and the associated localgov_skeleton theme, which have been superceded by the [localgov_base theme](https://github.com/localgovdrupal/localgov_base) documentation for which is in production.**</span>
+
+***
+
 [GitHub Repository](https://github.com/localgovdrupal/localgov_skeleton)
 
 The base theme we encourage you to use to build upon. The theme offers no styling or javascript functionality whatsoever and only contains twig templates.
 
-The base theme it's based on is `classy` and it sets up several regions you might need and are used in our frontend theme. 
+The base theme it's based on is `classy` and it sets up several regions you might need and are used in our frontend theme.
 
 There are currently no preprocess hooks written.
 

--- a/docs/src/theme/styling.md
+++ b/docs/src/theme/styling.md
@@ -1,5 +1,11 @@
 # Styling
 
+## Deprecated
+
+<span style="color:#B30000;">**This documentation is for the original localgov_theme and the associated localgov_skeleton theme, which have been superceded by the [localgov_base theme](https://github.com/localgovdrupal/localgov_base) documentation for which is in production.**</span>
+
+***
+
 The theme is using SASS with [Bootstrap 4](https://getbootstrap.com/docs/4.5/getting-started/introduction/) and is compiled to CSS with Gulp. All source files can be found in `/assets/scss`, each file will be compiled into a file with the same name and folder structure into `/assets/css` that you can then include in your Drupal libraries. Files with names beginning with an underscore `_` will be ignored by the compiler, but they can still be imported into other SASS files.
 
 ## Bootstrap


### PR DESCRIPTION
Closes #57 

With localgov_base now in the distribution the theme documentation is out of date. This PR adds a temporary deprecation notice on all theme documentation pages while the base theme documentation is prepared.