### PR TITLE
News added to sitemap

### DIFF
--- a/docs/src/devs/features/news-technical.md
+++ b/docs/src/devs/features/news-technical.md
@@ -90,7 +90,7 @@ Default menu: `none`
 :::
 
 ::: details Simple XML Sitemap
-Included: `false`
+Included: `true`
 
 :::
 
@@ -127,7 +127,7 @@ Default menu: `<main>`
 :::
 
 ::: details Simple XML Sitemap
-Included: `false`
+Included: `true`
 
 :::
 

--- a/docs/src/devs/general/content-types.md
+++ b/docs/src/devs/general/content-types.md
@@ -10,9 +10,9 @@ A full list of content types.
 | Event | An event to appear in the events listing and optionally integrate into a directory. | main | true |
 | Guide overview | Main guide page. | main | true |
 | Guide page | Page associated with a guide overview page. | main | true |
-| News article| A stand-alone news article that may also appear in a news listing page. | none | false |
-| Newsroom | A page for listing and featuring news articles. | main | false |
-|Service landing page |Top level section page for each service.| main | true |
+| News article| A stand-alone news article that may also appear in a news listing page. | none | true |
+| Newsroom | A page for listing and featuring news articles. | main | true |
+| Service landing page |Top level section page for each service.| main | true |
 | Service page | Basic page that can be placed in a service and on a service sub landing page. | main | true |
 | Service status | Page to display the status of a service on its service landing page and status lists. | main | true |
 | Service sub-landing page | Pages for detail and links to specific pages within a service. | main | true |


### PR DESCRIPTION
If https://github.com/localgovdrupal/localgov_news/pull/90 is merged, the docs should also be updated.

Despite this being mentioned in the docs, I think the intended behaviour was to include news articles in the sitemap, as there was a config file for that - it just doesn't apply due to some kind of bug, which the other PR fixes.