### PR TITLE
Update patterns.md - remove dead link to B&H patterns

### DIFF
--- a/docs/src/content/patterns.md
+++ b/docs/src/content/patterns.md
@@ -2,9 +2,6 @@
 
 Below are some components available through the WYSIWYG editor. 
 
-You may also like to take a look at the [Pattern Library created by Brighton & Hove City Council](https://design.brighton-hove.gov.uk/index.php?p=welcome), which illustrates how the implement many of the features. 
-
-
 ## Stand out content
 
 ### Alerts


### PR DESCRIPTION
The "Pattern Library created by Brighton & Hove City Council" link leads to a 403 Permission Denied page.

@andybroomfield clarified that there is no up-to-date replacement, so I suggest we remove this paragraph altogether.

Related discussion: #259 

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)