### PR TITLE
Update README.md - add jpoesen as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ This project is currently maintained by:
  - Maria Young https://github.com/msayoung
  - Finn Lewis https://github.com/finnlewis
  - Michael Wignall https://github.com/MichaelDCR
+ - Joeri Poesen https://github.com/jpoesen


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Add's jpoesen as maintainer

Previously merged to master rather than main.