### PR TITLE
fix: replace markdown mailto link with html

### DIFF
--- a/docs/src/devs/index.md
+++ b/docs/src/devs/index.md
@@ -23,7 +23,7 @@ We also encourage contributions from suppliers supporting councils using LocalGo
 
 ### Technical Slack channel
 
-The #technical-group #frontend slack channels are good places to find out who else is involved or ask for help. Email [hello@localgovdrupal.org](hello@localgovdrupal.org) if you'd like to join the LocalGov Drupal Slack community.
+The #technical-group #frontend slack channels are good places to find out who else is involved or ask for help. Email <a href="mailto:hello@localgovdrupal.org">hello@localgovdrupal.org</a> if you'd like to join the LocalGov Drupal Slack community.
 
 ### Technical Drop-in (Fortnightly Thursdays) and Merge Mondays (every Monday)
 


### PR DESCRIPTION
## What does this change?

This PR changes the markdown mailto link on the markdown page used to create the [For Developers](https://docs.localgovdrupal.org/devs/) documentation page to an HTML link because the markdown link gets transformed into `<a href="hello@localgovdrupal.org">hello@localgovdrupal.org</a>` (which gets interpreted as a relative link to a html document).

It's possible changing it to hello@localgovdrupal.org would also work, as Github manages to convert that to a correct mailto link in this sentence.

## How to test

## How can we measure success?

1. click the hello@localgovdrupal.org link on [the live version of the page](https://docs.localgovdrupal.org/devs/): the browser navigates to https://docs.localgovdrupal.org/devs/hello@localgovdrupal.org
2. click on the hello@localgovdrupal.org link on [the html generated by the changed markdown](https://deploy-preview-272--inspiring-euclid-d918c8.netlify.app/devs/): it behaves as a mailto link

## Have we considered potential risks?

n/a

## Images

n/a

## Accessibility

n/a