### PR TITLE
Map out the effect of microsite colour settings.

### DIFF
--- a/docs/src/microsites/how-to/manage-site-settings.md
+++ b/docs/src/microsites/how-to/manage-site-settings.md
@@ -1,1 +1,55 @@
 # Site settings (microsite admin)
+
+
+## Colour Settings
+
+There are many colour options for a microsite, which means that it is possible to create visually distinct sites without touching any code.
+
+By default, when using the Localgov Microsites Base theme, you can effect colour changes as follows:
+
+### Global Settings
+
+1. Primary Colour
+  - Page-wide H2 headings
+  - Header links, e.g. menu items
+  - Primary banner background colour
+  - Submit buttons background colour
+  - Rich layout section with background colour 1, background colour
+  - Rich layout section with background colour 2, text colour
+  - Footer background colour
+
+2. Primary Contrast Colour
+  - Primary banner text
+  - Submit button text colour, and submit button hover state background colour
+  - Rich layout section with background colour 1, text colour
+  - Page-wide Links
+  - Footer content block text
+  - Footer links
+
+3. Secondary Colour
+  - Header link hover colour
+  - Rich layout section with background colour 2, background colour
+  - Footer links hover colour
+
+4. Secondary Contrast Colour
+  - Form input label colour
+  - Form input border
+  - Form submit button background
+  - Rich layout section with background colour 2, text colour
+
+5. Text Colour
+  - Page-wide default text colour. NB more specific rules will override this default text colour.
+
+6. Page Background Colour
+  - Page-wide background. NB specified regions and content sections can have their own background colours which will sit in front of this.
+7. Link
+  - Any link that doesn't already have a colour.
+
+### Layouts and rich content
+
+1. Section colours use global colours
+  1. Primary colour for background, and primary contrast colour for text
+  2. Secondary colour for background, and secondary contrast colour for text
+  3. White background and black text.
+2. Text component
+  1. Background colour setting has no effect.


### PR DESCRIPTION
## What does this change?

Adds a mapping of colour settings for a microsite, to show where one might expect to see the effect of each choice.

Includes: global styles, and some rich content and layout components.