### PR TITLE
Update php docs with reference to php-fpm and cache debug headers.

### DIFF
--- a/docs/src/devs/getting-started/drupal-requirements.md
+++ b/docs/src/devs/getting-started/drupal-requirements.md
@@ -37,7 +37,10 @@ You can find more information about Drupal's PHP extension requirements
 
 ### PHP-FPM
 
-Localgov drupal can be run using PHP-FPM. Please note that when using for development the default configuration will output all of Drupal's cache tags for that page as http headers. This can cause the site to crash if there are many headers. It can be resolved by turning these off in `/web/sites/development.services.yml` and setting `http.response.debug_cacheability_header: false`.
+Localgov drupal can be run using PHP-FPM. Please note that when using for development the default configuration will output all of Drupal's cache tags for that page as http headers. This can cause the site to crash if there are many headers. It can be resolved by turning these off in:
+`/web/sites/development.services.yml`
+and setting
+`http.response.debug_cacheability_header: false`.
 
 ## A database server like MySQL
 You can find detailed information about Drupal's database server requirements 

--- a/docs/src/devs/getting-started/drupal-requirements.md
+++ b/docs/src/devs/getting-started/drupal-requirements.md
@@ -35,6 +35,10 @@ You will also need to have certain PHP extensions enabled including:
 You can find more information about Drupal's PHP extension requirements 
 [here](https://www.drupal.org/docs/system-requirements/php-requirements#extensions))
 
+### PHP-FPM
+
+Localgov drupal can be run using PHP-FPM. Please note that when using for development the default configuration will output all of Drupal's cache tags for that page as http headers. This can cause the site to crash if there are many headers. It can be resolved by turning these off in `/web/sites/development.services.yml` and setting `http.response.debug_cacheability_header: false`.
+
 ## A database server like MySQL
 You can find detailed information about Drupal's database server requirements 
 [here](https://www.drupal.org/docs/system-requirements/database-server-requirements).


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

Fix #295 

## What does this change?

Adds information about the debug headers that can cause a site crash under PHP-FPM.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

This page of the update branch
[/devs/getting-started/drupal-requirements.html#php](https://deploy-preview-296--inspiring-euclid-d918c8.netlify.app/devs/getting-started/drupal-requirements.html#php)

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

