### PR TITLE
Update how-to-manage-menus.md

### DIFF
--- a/docs/src/content/how-to/how-to-manage-menus.md
+++ b/docs/src/content/how-to/how-to-manage-menus.md
@@ -7,7 +7,7 @@
 Visit the Menu Overview by:
 
 - navigating via Admin > Structure > Menus
-- visit yourdomain.gov.uk/admin/structure/menus
+- visit yourdomain.gov.uk/admin/structure/menu
 
 This page shows a table of all the menus in use in the website, with a description of each and an Edit Menu button for each row. If you don't see an Edit Menu button it means you don't have permission to edit the menu.
 


### PR DESCRIPTION
Typo - 

The correct path to view and manage menus is:

/admin/structure/menu

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

The second list item in the 'Menu overview page' (see screenshot below) directs to a 404 page, it should read visit `yourdomain.gov.uk/admin/structure/menu`


![image](https://github.com/user-attachments/assets/7930d45b-6e95-4578-8c19-2fc86af9745b)
