### PR TITLE
Added page listing node types.

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -217,6 +217,7 @@ export default defineUserConfig({
           link: '/content/features/',
           collapsible: true,
           children: [
+            '/content/features/content-types',
             '/content/features/services',
             '/content/features/alert-banner',
             '/content/features/directories',

--- a/docs/src/content/features/content-types.md
+++ b/docs/src/content/features/content-types.md
@@ -1,0 +1,73 @@
+# Content types
+
+A LocalGov Drupal site will typically have a number of different [content types](/content/#drupal-terminology), each suited to a particular purpose.
+
+This page gives an overview of these different types. Note that not all content types may be available on your site, depending on which LocalGov Drupal modules have been installed.
+
+## Directory channel
+
+A page where users will be presented with a searchable or filterable list of directory items.
+
+Directory items can be directory pages, directory organisations, directory venues, or custom content types.
+
+See [Directories](/content/features/directories.md) for more detail.
+
+## Directory organisation
+
+An organisation to show in a directory, e.g. a library or a school. Either as first class directory entry, or used for Open Referral directory entries.
+
+## Directory venue
+
+A venue with a location to show in a directory, e.g. a sports facility or a park.
+
+## Event
+
+An event to appear in the events listing.
+
+## Service landing page
+
+The top level page for a service.
+
+See [Services](/content/features/services.md) for more detail.
+
+## Service page
+
+The basic page that can be placed in a service, and on a Service Sub-landing Page.
+
+## Service status
+
+Shows updates about the status of a service.
+
+## Service sub-landing page
+
+Shows detail and links to specific pages within a service.
+
+## Subsite overview
+
+The landing page for a subsite.
+
+See [Subsites](/content/features/subsites.md) for more detail.
+
+## Subsite page
+
+A child page in a subsite. This needs a 'Subsite overview' that it refers to.
+
+## Step by step overview
+
+The main page for a step-by-step process.
+
+See [Step by step](/content/features/step-by-step.md) for more detail.
+
+## Step by step page
+
+A single step in a step-by-step process. This needs a 'Step by step overview' content item that it refers to.
+
+## Guide overview
+
+The main page for a collection of connected pages, where there's no set process to be followed. Links on each guide page allow the user to move through the guide.
+
+See [Guide](/content/features/guide.md) for more detail.
+
+## Guide page
+
+A single page in a guide. This needs a 'Guide overview' content item that it refers to.

--- a/docs/src/content/index.md
+++ b/docs/src/content/index.md
@@ -21,6 +21,9 @@ We've put together a series of How-to videos which are here in the documentation
 
 Descriptions of the [features of LocalGov Drupal](https://docs.localgovdrupal.org/content/features/) that are useful for content editors and content designers, with guidance on what the feature is designed for, and how it was intended to be used. 
 
+## Content types
+
+An overview of the [different content types provided by LocalGov Drupal](/content/features/content-types.md).
 
 ## Patterns and Components
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #328 .

Adds a page listing all LGD node types, because content authors are faced with the list at /node/add and are confused.


## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)