### PR TITLE
Fix the good first issue link

### DIFF
--- a/docs/src/contributing/development.md
+++ b/docs/src/contributing/development.md
@@ -9,5 +9,5 @@ Not sure where to start?
 - Come along to [Merge Monday or Technical Drop-in](https://calendar.google.com/calendar/u/0/embed?src=dnkea9ec90vrkdnrmlo1ng3dik@group.calendar.google.com&ctz=Europe/London&pli=1)
 - Help [work on an issue](https://github.com/search?q=org%3Alocalgovdrupal+label%3A%22help+wanted%22+&type=issues)
 - Review [open pull requests](https://github.com/search?q=org%3Alocalgovdrupal+type%3Apr+is%3Aopen+&type=pullrequests)
-- New developer? Take a look at a [good first issue](https://github.com/search?q=org%3Alocalgovdrupal%20label%3A%22good%20first%20issue%22%20&type=issues)
+- New developer? Take a look at a [good first issue](https://github.com/search?q=org%3Alocalgovdrupal+label%3A%22good+first+issue%22+++type%3Aissue+state%3Aopen&type=issues&state=open)
 


### PR DESCRIPTION
Was pointing to include closed issues. Looks like Github had updated the url format.

Points the link to https://github.com/search?q=org%3Alocalgovdrupal+label%3A%22good+first+issue%22+++type%3Aissue+state%3Aopen&type=issues&state=open