### PR TITLE
Change Merge Monday to Tuesday and fix calendar link

### DIFF
--- a/docs/src/contributing/development.md
+++ b/docs/src/contributing/development.md
@@ -6,7 +6,7 @@ Not sure where to start?
 - Read the [contribution guidelines](https://github.com/localgovdrupal/localgov/blob/3.x/CONTRIBUTING.md)
 - Get [set up locally](https://docs.localgovdrupal.org/devs/getting-started/), play around and find out how things work
 - Join the Slack Technical channel and ask questions
-- Come along to [Merge Monday or Technical Drop-in](https://calendar.google.com/calendar/u/0/embed?src=dnkea9ec90vrkdnrmlo1ng3dik@group.calendar.google.com&ctz=Europe/London&pli=1)
+- Come along to [Merge Tuesday or Technical Drop-in](https://lu.ma/localgovdrupal?tag=tech)
 - Help [work on an issue](https://github.com/search?q=org%3Alocalgovdrupal+label%3A%22help+wanted%22+&type=issues)
 - Review [open pull requests](https://github.com/search?q=org%3Alocalgovdrupal+type%3Apr+is%3Aopen+&type=pullrequests)
 - New developer? Take a look at a [good first issue](https://github.com/search?q=org%3Alocalgovdrupal+label%3A%22good+first+issue%22+++type%3Aissue+state%3Aopen&type=issues&state=open)


### PR DESCRIPTION
Noticed this is still pointing to merge Mondays.
Have changed it to Tuesday, and also updated the link as it points to a blank calendar. Wasn't sure where so went with the luma tech events tag.