### PR TITLE
Revise paragraphs documentation with new types and details

### DIFF
--- a/docs/src/content/features/paragraphs.md
+++ b/docs/src/content/features/paragraphs.md
@@ -21,9 +21,7 @@ We'll add to this section once we've finished our review of the UX.
 
 ## Paragraph types
 
-Here's the [complete list](https://docs.google.com/document/d/1OJ6lA_8tzHyKWOdpz3hGGIpB-2f9o5JcTn837Whfr5c/edit?usp=sharing).
-
-Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sharing this.
+Here's the [complete list](https://docs.google.com/document/d/1OJ6lA_8tzHyKWOdpz3hGGIpB-2f9o5JcTn837Whfr5c/edit?usp=sharing). Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sharing this.
 
 ### Accordion
 
@@ -92,6 +90,55 @@ localgov_banner_secondary
 * Image*
 
 <img width="949" height="421" alt="Screenshot 2026-02-12 at 14 55 02" src="https://github.com/user-attachments/assets/56c83ecf-9f07-45f6-84dc-ee33783e9126" />
+
+
+### Block view
+
+TBC: paragraph to add a listing (Drupal “View”)to a page (eg. events block, news listing etc)
+
+**Machine name**
+
+localgov_block_view
+
+**Fields**
+
+*Block view / display*
+
+
+### Box link
+
+A button element which can be added with or without an image. Can be used on its own or as part of a “Box links listing”
+
+**Machine name**
+
+localgov_box_link
+
+**Fields**
+
+* Image
+* Link / link text
+* Open in a new window (Yes/No)
+
+
+### Box links listing
+
+A grid / listing of buttons, each with or without an image
+
+**Machine name**
+
+localgov_box_links_listing
+
+**Fields**
+
+* Title
+* Heading level
+* Box listing theme (Grid / Boxes)
+* Ability to add multiple box links, each with Image, Link / link text, Open in a new window (Yes/No)
+
+**Image of Box link and Box links listing**
+
+<img width="419" height="150" alt="Screenshot 2026-02-12 at 15 11 04" src="https://github.com/user-attachments/assets/c38542b8-6c90-4d9d-82cc-b0980c2055d7" />
+
 
 -------
 ### 


### PR DESCRIPTION
Updated the paragraphs documentation to include new paragraph types and their machine names. Removed redundant acknowledgments and added details for block views and box links.

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)