### PR TITLE
Update config.js

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -8,7 +8,7 @@ const __dirname = getDirname(import.meta.url)
 
 export default defineUserConfig({
   title: 'LocalGov Drupal Docs',
-  description: 'LocalGov Drupal is an open source collaboration between UK councils and Drupal developers.',
+  description: 'LocalGov Drupal is an open source collaboration between UK councils and Drupal developers. Drupal is a registered trademark of Dries Buytaert.',
 
   port: 49728,
 


### PR DESCRIPTION
added "Drupal is a registered trademark of Dries Buytaert." to description.

To test, go to the homepage and check that this text appears in the footer.